### PR TITLE
feat: add dotfile-organizer skill, CLAUDE.md, and security guidelines

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "dot-files",
+  "description": "Personal dot-files skills for zsh environment management",
+  "version": "1.0.0",
+  "author": {
+    "name": "manboubird"
+  },
+  "repository": "https://github.com/manboubird/dot-files",
+  "skills": "../skills/"
+}

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,83 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this repo is
+
+A personal dotfiles repository for macOS. Files in `files/` are symlinked to `$HOME` via `setup/clone_and_link.sh`. Files in `files.tpl/` are templates to copy manually — they are never symlinked and never committed.
+
+## Verification commands
+
+After editing any zsh config file, always syntax-check it:
+
+```bash
+zsh -n <file>
+```
+
+After changes that affect shell startup:
+
+```bash
+zsh -i -c exit; echo "Exit: $?"          # interactive shell starts cleanly
+zsh -c 'echo $PATH' | tr ':' '\n'        # non-interactive PATH
+```
+
+## Zsh config architecture
+
+Load order — zsh sources these in sequence:
+
+1. **`files/.zshenv`** — sourced by ALL shells (interactive, non-interactive, scripts, cron). Contains only: XDG Base Directory vars, PATH (`.local/bin`, Homebrew), sources `~/.zshenv.local`. Ends with `typeset -U PATH` to deduplicate.
+2. **`files/.zshrc`** — interactive shells only. Loads: zsh-vi-mode, completions, pyenv, zoxide, then sources `~/.zshrc.local` and `~/.zshrc.after`.
+3. **`files/.zshrc.after`** — the command file loader. Sources `files/.zshrc.command/functions`, then loads each file listed in `_ZSHRC_CMD_FILES` from `files/.zshrc.command/`.
+
+**`files/.zshrc.command/functions`** defines two helpers used throughout command files:
+- `is_command_exists <cmd>` — echoes `0` if command exists, `1` if not (inverted from shell exit codes — do NOT change this convention, it's intentional for backward compatibility)
+- `source_files <dir> <files...>` — sources each named file from `<dir>`
+
+**`files/.zshrc.command/<tool>`** — one file per tool, guarded with `if [ $(is_command_exists <tool>) -eq 0 ]`.
+
+## Machine-local files (not committed)
+
+| Template | Copy to | Purpose |
+|----------|---------|---------|
+| `files.tpl/.zshenv.local` | `~/.zshenv.local` | Non-interactive env vars (bun PATH, etc.) |
+| `files.tpl/.zshrc.local` | `~/.zshrc.local` | Interactive overrides (EDITOR, optional tool paths) |
+| `files.tpl/.gitconfig.local` | `~/.config/git/config.local` | Git user identity |
+
+`~/.zshrc.local` must be sourced before `~/.zshrc.after` (already enforced in `files/.zshrc`) so that `_ZSHRC_CMD_FILES_OPT` is defined when the loader runs.
+
+## Key rules for editing zsh files
+
+- No hardcoded `/Users/<username>/` paths in any tracked file — use `$HOME` or `~`
+- `files/.zshenv` must stay minimal and fast: no aliases, no completions, no slow `eval` calls
+- `[[ ]]` is preferred over `[ ]` in zsh-only files (`.zshenv`, `.zshrc`, `.zshrc.after`, `.zshrc.command/*`)
+- Adding a new tool to the command file system: create `files/.zshrc.command/<tool>` and add the name to `_ZSHRC_CMD_FILES` in `files/.zshrc.after`
+
+## Security and privacy
+
+**Trust boundary — three tiers:**
+
+| Tier | Path | Committed | Contains |
+|------|------|-----------|---------|
+| Shared | `files/`, `files/.claude/`, `skills/` | Yes | Generic config, no personal data |
+| Template | `files.tpl/` | Yes | Structure only — placeholders, all values commented out |
+| Local | `~/*.local`, `~/.config/git/config.local` | Never | Real values, machine paths, credentials |
+
+**Hard rules for tracked files:**
+- No `export ..._TOKEN=`, `..._KEY=`, `..._SECRET=`, `..._PASSWORD=` with real values
+- No hardcoded usernames in paths — always `$HOME` or `~`, never `/Users/<name>/`
+- No private key material (`-----BEGIN ... PRIVATE KEY-----`)
+- `files.tpl/` entries must have values commented out or replaced with `<PLACEHOLDER>` — the template itself must contain no real values
+
+**Files that must never be committed:**
+`~/.zshrc.local`, `~/.zshenv.local`, `~/.config/git/config.local`, `~/.netrc`, `~/.ssh/*`, `~/.aws/credentials`, `~/.gnupg/`, `.env`, `.npmrc`, `.pypirc`
+
+**Before committing any file:** run the `security-scan` mode of the `dotfile-organizer` skill to catch leaks before they hit git history.
+
+## Setup guide
+
+Full new-machine setup: [`docs/setup/zshrc.md`](docs/setup/zshrc.md)
+
+## Brewfiles
+
+- `setup/Brewfile-core` — core tools for all machines
+- `setup/Brewfile-dev` — development tools (install selectively)

--- a/docs/setup/dotfile-organizer.md
+++ b/docs/setup/dotfile-organizer.md
@@ -1,0 +1,39 @@
+# Dotfile Organizer Skill — Setup
+
+The `dotfile-organizer` skill helps you audit, configure, and port dot-files based on your machine's installed tools.
+
+## Install the skill
+
+The skill is bundled in the dot-files repo as a Claude Code plugin. Install it once via the Claude Code `/plugin` command.
+
+**If you installed the dot-files repo from GitHub:**
+
+```
+/plugin marketplace add manboubird/dot-files
+/plugin install dotfile-organizer@dot-files
+```
+
+**If you have the repo cloned locally:**
+
+```
+/plugin marketplace add ~/dot-files
+/plugin install dotfile-organizer@dot-files
+```
+
+Run `/reload-plugins` if the skill doesn't appear immediately.
+
+## Install .claude files
+
+Files in `files/.claude/` are git-managed but require a manual one-time copy since `clone_and_link.sh` cannot safely replace your live `~/.claude/` directory.
+
+```bash
+cp ~/dot-files/files/.claude/statusline.sh ~/.claude/statusline.sh
+```
+
+## What the skill does
+
+| Mode | Example trigger | Output |
+|------|----------------|--------|
+| **organize** | "what should I configure in .zshrc.local?" | Checklist of .zshenv.local and .zshrc.local entries based on installed tools |
+| **setup** | "generate a setup checklist for this machine" | Numbered guide saved to `docs/setup/setup-<hostname>.md` |
+| **port** | "what configs should I move into the repo?" | Candidate files with exact move + copy commands |

--- a/files/.claude/statusline.sh
+++ b/files/.claude/statusline.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# ~/.claude/statusline.sh
+# Claude Code status line script
+# Receives JSON from Claude Code via stdin
+
+input=$(cat)
+
+# ── 1. 現在のフォルダ名 ──────────────────────────────────────────────────────
+cwd=$(echo "$input" | jq -r '.workspace.current_dir // .cwd // ""')
+[ -z "$cwd" ] && cwd="$(pwd)"
+folder=$(basename "$cwd")
+
+# ── 2. Git リポジトリ名 | ブランチ名 ────────────────────────────────────────
+git_line=""
+if git -C "$cwd" rev-parse --git-dir > /dev/null 2>&1; then
+  repo=$(basename "$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null)")
+  branch=$(git -C "$cwd" --no-optional-locks symbolic-ref --short HEAD 2>/dev/null \
+           || git -C "$cwd" --no-optional-locks rev-parse --short HEAD 2>/dev/null)
+  git_line="${repo} | ${branch}"
+fi
+
+# ── 3. コンテキスト使用量 | モデル ──────────────────────────────────────────
+model=$(echo "$input" | jq -r '.model.display_name // ""')
+
+used_pct=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
+total=$(echo "$input" | jq -r '.context_window.context_window_size // empty')
+used_tokens=$(echo "$input" | jq -r '.context_window.current_usage.input_tokens // empty')
+
+if [ -n "$used_tokens" ] && [ -n "$total" ] && [ -n "$used_pct" ]; then
+  used_k=$(awk "BEGIN {printf \"%.1fk\", $used_tokens/1000}")
+  total_k=$(awk "BEGIN {printf \"%.0fk\", $total/1000}")
+  pct=$(printf "%.0f" "$used_pct")
+  ctx_line="コンテキスト: ${used_k}/${total_k} (${pct}%) | ${model}"
+elif [ -n "$model" ]; then
+  ctx_line="コンテキスト: - | ${model}"
+else
+  ctx_line="コンテキスト: -"
+fi
+
+# ── 4. 累計トークン使用量 (5h/7d はAPI未提供のため、セッション累計で代替) ──
+total_in=$(echo "$input" | jq -r '.context_window.total_input_tokens // empty')
+total_out=$(echo "$input" | jq -r '.context_window.total_output_tokens // empty')
+
+if [ -n "$total_in" ] && [ -n "$total_out" ]; then
+  total_in_k=$(awk "BEGIN {printf \"%.1fk\", $total_in/1000}")
+  total_out_k=$(awk "BEGIN {printf \"%.1fk\", $total_out/1000}")
+  reset_7d=$(date -v+7d +"%m/%d" 2>/dev/null || date --date="+7 days" +"%m/%d" 2>/dev/null || echo "?")
+  reset_5h=$(date -v+5H +"%H:%M" 2>/dev/null || date --date="+5 hours" +"%H:%M" 2>/dev/null || echo "?")
+  usage_line="セッション計: 入力${total_in_k} 出力${total_out_k} | 5hリセット: ${reset_5h}  7dリセット: ${reset_7d}"
+else
+  usage_line="使用量: データなし"
+fi
+
+# ── 出力 ─────────────────────────────────────────────────────────────────────
+printf "%s\n" "$folder"
+[ -n "$git_line" ] && printf "%s\n" "$git_line"
+printf "%s\n" "$ctx_line"
+printf "%s\n" "$usage_line"

--- a/skills/dotfile-organizer/SKILL.md
+++ b/skills/dotfile-organizer/SKILL.md
@@ -1,0 +1,259 @@
+---
+name: dotfile-organizer
+description: Organize, audit, port, and security-scan dot-files based on the current machine environment. Use this skill when the user wants to: audit which .zshrc.command files should be active for their installed tools, figure out what to put in .zshrc.local or .zshenv.local, generate a customized step-by-step setup checklist for a new machine, identify machine-specific config files that should be moved into the git-managed dot-files repo, or scan tracked files for accidentally committed secrets, hardcoded usernames, or privacy leaks before pushing. Trigger whenever the user mentions organizing dot-files, setting up a new machine, porting configs into the repo, auditing their shell configuration, or checking dotfiles for security or privacy issues.
+---
+
+# Dotfile Organizer
+
+Four modes — pick based on what the user is asking for:
+
+- **organize**: Scan the environment, cross-reference with the dot-files repo, propose what to enable or configure
+- **setup**: Generate a step-by-step machine-specific setup checklist
+- **port**: Identify machine-specific config files outside the repo that should be git-managed, and generate the commands to move them in
+- **security-scan**: Scan tracked files for secrets, hardcoded usernames, and privacy leaks before they reach git history
+
+---
+
+## Mode 1: Organize
+
+### Step 1: Scan the environment
+
+Run these in parallel:
+
+```bash
+# Tool availability
+for cmd in ack ag bat bun cheat direnv gcloud ghq httpie ipython mise node nvim peco pet pyenv tmux tree w3m zoxide; do
+  command -v "$cmd" &>/dev/null && echo "ok $cmd" || echo "-- $cmd"
+done
+
+# Current local configs
+cat ~/.zshrc.local 2>/dev/null || echo "(no ~/.zshrc.local)"
+cat ~/.zshenv.local 2>/dev/null || echo "(no ~/.zshenv.local)"
+
+# What's in the standard command file list
+grep '_ZSHRC_CMD_FILES=' ~/dot-files/files/.zshrc.after 2>/dev/null
+```
+
+### Step 2: Map tools to command files
+
+| Command file | Requires | Notes |
+|---|---|---|
+| `ack` | `ack` | |
+| `ag` | `ag` | |
+| `cd` | — | Always |
+| `cheat` | `cheat` | |
+| `curl` | — | Always |
+| `df` | — | Always |
+| `direnv` | `direnv` | |
+| `du` | — | Always |
+| `fcd` | `peco` | fuzzy-cd |
+| `find` | — | Always |
+| `google-cloud-sdk` | `gcloud` | |
+| `ghq` | `ghq` | also benefits from `peco` |
+| `http` | `httpie` | |
+| `ipython` | `ipython` | |
+| `less` | — | Always |
+| `ls` | — | Always |
+| `nodejs` | `node` | |
+| `open` | — | macOS, always |
+| `openssl` | — | Always |
+| `pbcopy` | — | macOS, always |
+| `pbpaste` | — | macOS, always |
+| `pet` | `pet` | |
+| `tmux` | `tmux` | |
+| `tree` | `tree` | |
+| `w3m` | `w3m` | |
+
+### Step 3: Produce a proposal as a checklist
+
+**A. `.zshenv.local`** — tools needed in non-interactive shells (scripts, cron):
+- If `bun` is installed → uncomment the bun block
+- Any runtime tool installed outside Homebrew whose PATH must be available to scripts
+
+**B. `.zshrc.local`** — interactive shell settings:
+- `export EDITOR=` — detect `nvim` / `vim` / `code` and suggest the right value
+- `export PATH=` lines for interactive-only tools (LM Studio, Antigravity)
+- `_ZSHRC_CMD_FILES_OPT=(...)` — any installed tools NOT in the standard `_ZSHRC_CMD_FILES` list
+
+**C. Command file audit** — show ✓ for files whose tool is installed, and flag any tool in `_ZSHRC_CMD_FILES_OPT` that could be promoted to the standard list via a PR.
+
+---
+
+## Mode 2: Setup
+
+Run the same environment scan from Mode 1 first, then generate a numbered, copy-pasteable checklist:
+
+```
+# Dot-files setup — <hostname> (<YYYY-MM-DD>)
+
+## 1. Clone and link (skip if already done)
+git clone git@github.com:<user>/dot-files.git ~/dot-files
+ln -s ~/dot-files ~/.dot-files
+bash ~/dot-files/setup/clone_and_link.sh
+
+## 2. Install .claude files
+mkdir -p ~/.claude
+ln -sf ~/dot-files/files/.claude/statusline.sh ~/.claude/statusline.sh
+
+## 3. Install dotfile-organizer skill
+mkdir -p ~/.claude/skills
+ln -sf ~/dot-files/skills/dotfile-organizer ~/.claude/skills/dotfile-organizer
+
+## 4. Install missing tools
+brew install <only what's detected as missing>
+
+## 5. Configure ~/.zshenv.local
+cp ~/dot-files/files.tpl/.zshenv.local ~/.zshenv.local
+# <exact lines to uncomment based on what's installed>
+
+## 6. Configure ~/.zshrc.local
+cp ~/dot-files/files.tpl/.zshrc.local ~/.zshrc.local
+# <exact lines to set: EDITOR, PATH entries>
+
+## 7. Verify
+zsh -i -c exit; echo "Exit: $?"
+zsh -i -c "alias ll; type is_command_exists"
+```
+
+Save to `docs/setup/setup-<hostname>.md` (not committed — local reference). Tell the user the path.
+
+---
+
+## Mode 3: Port
+
+Identify config files on this machine that are currently untracked but shareable (no secrets, useful across machines), then generate the commands to move them into the repo.
+
+### Step 1: Scan candidate locations
+
+```bash
+# .claude/ files (non-dynamic, non-secret)
+ls -la ~/.claude/*.sh ~/.claude/*.json 2>/dev/null | grep -v settings.json
+
+# Already in repo?
+ls ~/dot-files/files/.claude/ 2>/dev/null
+
+# Custom scripts
+ls ~/.local/bin/ ~/local/bin/ 2>/dev/null
+
+# Other common candidates
+ls ~/.ackrc ~/.ctags ~/.screenrc 2>/dev/null
+```
+
+### Step 2: Classify each candidate
+
+For each file found, decide:
+
+| Destination | When to use |
+|---|---|
+| `files/.claude/<file>` | Shareable as-is, no secrets, same on every machine |
+| `files.tpl/.claude/<file>` | Has machine-specific values; share as template with placeholders |
+| `files/<dotfile>` | Standard dotfile, symlinked by `clone_and_link.sh` |
+| Skip | Dynamic state, secrets, or machine-specific data that doesn't generalize |
+
+**Key rules:**
+- `~/.claude/settings.json` → `files.tpl/.claude/` (contains machine-specific paths/keys, share as template)
+- `~/.claude/statusline.sh` → `files/.claude/` (fully shareable script)
+- `~/.claude/` dynamic dirs (`projects/`, `sessions/`, `cache/`, etc.) → skip always
+
+### Step 3: Generate port commands
+
+For each file to port, output the exact commands:
+
+```bash
+# Example: statusline.sh
+cp ~/.claude/statusline.sh ~/dot-files/files/.claude/statusline.sh
+ln -sf ~/dot-files/files/.claude/statusline.sh ~/.claude/statusline.sh
+# Then: git add ~/dot-files/files/.claude/statusline.sh
+```
+
+**Note:** `~/.claude/` cannot be fully symlinked by `clone_and_link.sh` (the directory already exists with dynamic content). Individual files within it must be symlinked one by one. The setup mode generates these individual symlink commands.
+
+### Step 4: Output a port plan
+
+Present as a checklist:
+- `- [ ] Port <file>: move to <repo-path>, symlink from <original-path>`
+- After each group, show the `git add` commands to stage them
+
+---
+
+## Mode 4: Security Scan
+
+Scan the tracked and staged files for secrets, personal data, and privacy leaks **before they enter git history**. Run this before any `git push` on this repo.
+
+### Step 1: Scan tracked files for secrets
+
+```bash
+# Secret patterns in tracked files
+git grep -n -E \
+  'export [A-Z_]*(TOKEN|KEY|SECRET|PASSWORD|CREDENTIAL|AUTH)[=\s][^$(<"'"'"']' \
+  -- 'files/' 'files.tpl/'
+
+# Private key material
+git grep -n 'BEGIN.*PRIVATE KEY' -- 'files/' 'files.tpl/'
+
+# Common token formats
+git grep -n -E \
+  '(ghp_|gho_|ghu_|ghs_)[A-Za-z0-9]{36}|AKIA[0-9A-Z]{16}' \
+  -- 'files/' 'files.tpl/'
+```
+
+### Step 2: Scan for hardcoded personal paths
+
+```bash
+# Username in paths (should always use $HOME or ~)
+git grep -n -E '/Users/[a-zA-Z0-9_]+/' -- 'files/' 'files.tpl/'
+git grep -n -E '/home/[a-zA-Z0-9_]+/' -- 'files/' 'files.tpl/'
+```
+
+### Step 3: Check for dangerous files accidentally tracked
+
+```bash
+# High-risk filenames that should never be committed
+git ls-files | grep -E \
+  '(\.ssh/|\.gnupg/|\.aws/credentials|\.netrc|\.pypirc|\.npmrc|\.env$|\.env\.)'
+
+# .local files (should all be gitignored)
+git ls-files | grep '\.local$'
+```
+
+### Step 4: Validate files.tpl/ contains no real values
+
+Templates are safe to commit only if values are commented out or use placeholders. Check:
+
+```bash
+# Lines in files.tpl/ that look like active (uncommented) credential exports
+grep -rn -E '^export [A-Z_]*(TOKEN|KEY|SECRET|PASSWORD)=' files.tpl/
+
+# Active (uncommented) path entries that look real (not <PLACEHOLDER>)
+grep -rn -E '^export PATH=.*/(bin|lib)' files.tpl/ | grep -v '#'
+```
+
+### Step 5: Check .gitignore coverage
+
+```bash
+# Verify these patterns are covered
+for pattern in '*.local' '.env' '.npmrc' '.pypirc' '.netrc' \
+               '.aws' '.gnupg' '.ssh'; do
+  git check-ignore -q --no-index "$pattern" 2>/dev/null \
+    && echo "✓ $pattern" || echo "✗ NOT ignored: $pattern"
+done
+```
+
+### Output format
+
+Report findings in three categories:
+
+**🔴 Errors** — must fix before pushing (real secrets, private keys, live credentials)
+**🟡 Warnings** — review needed (uncommented template values, suspicious patterns)
+**✅ Clean** — no issues found in this category
+
+For each finding: show the file, line number, and the matched content. If errors are found, suggest the fix (move the value to a `.local` file, add to `.gitignore`, or replace with a placeholder in `files.tpl/`).
+
+---
+
+## Style rules
+
+- Use `- [ ]` checkboxes for all action items
+- Always explain *why* a file belongs where it does ("no secrets + same content on any machine → `files/`")
+- Show exact commands — no abstract descriptions
+- Distinguish "already in repo" (nothing to do) from "missing" (action required)

--- a/skills/dotfile-organizer/evals/evals.json
+++ b/skills/dotfile-organizer/evals/evals.json
@@ -1,0 +1,35 @@
+{
+  "skill_name": "dotfile-organizer",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I just set up a new Mac and cloned my dot-files repo. Scan what's installed and tell me what I need to configure in .zshrc.local and .zshenv.local.",
+      "expected_output": "Environment scan, tool-to-command-file mapping, specific .zshrc.local and .zshenv.local recommendations with exact content",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "Which of my .zshrc.command files should be active on this machine based on what's installed?",
+      "expected_output": "Audit of each command file vs installed tools with ✓/✗, suggestion for _ZSHRC_CMD_FILES_OPT if any installed tools are missing from standard list",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "Generate a step-by-step setup checklist for this machine so I can get my dot-files fully configured.",
+      "expected_output": "Numbered copy-pasteable checklist saved to docs/setup/setup-<hostname>.md covering tool installs, .zshenv.local, .zshrc.local, .claude file symlinks, and verification",
+      "files": []
+    },
+    {
+      "id": 4,
+      "prompt": "What config files on my machine aren't tracked in the dot-files repo but should be? I want to port ~/.claude/statusline.sh and any other good candidates.",
+      "expected_output": "Scan of candidate files, classification of each (files/ vs files.tpl/ vs skip), exact mv+copy+git add commands for each file to port",
+      "files": []
+    },
+    {
+      "id": 5,
+      "prompt": "Before I push this branch, can you check if I've accidentally committed any secrets or personal info to the dot-files repo?",
+      "expected_output": "Security scan across tracked files: secret pattern search, hardcoded path check, dangerous file check, files.tpl/ validation, .gitignore coverage — results as 🔴/🟡/✅ with file:line references for any findings",
+      "files": []
+    }
+  ]
+}


### PR DESCRIPTION
- Add .claude/CLAUDE.md with repo architecture, zsh config overview, and security/privacy trust boundary (files/ vs files.tpl/ vs local)
- Add .claude-plugin/plugin.json to expose repo as Claude Code plugin
- Add skills/dotfile-organizer with 4 modes: organize, setup, port, and security-scan (checks for secrets, hardcoded paths, gitignore gaps)
- Add files/.claude/statusline.sh to git-manage the Claude statusline script
- Add docs/setup/dotfile-organizer.md with /plugin install instructions