### PR TITLE
feat: add exclude/default lists and idempotent symlink creation to clone_and_link.sh

### DIFF
--- a/setup/clone_and_link.sh
+++ b/setup/clone_and_link.sh
@@ -5,6 +5,46 @@ DOT_FILES_DIR="${DOT_FILES_DIR:-$HOME/.dot-files}"
 DOT_DIR="$DOT_FILES_DIR/dot"
 XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
 
+# Files in dot/ that are never symlinked (legacy, machine-specific, or unused)
+DOT_EXCLUDE=(
+  bash_logout
+  bash_profile
+  bashrc
+  bashrc.after
+  bashrc.command
+  ctags
+  drake
+  gvimrc
+  ivy2
+  jenkins-clirc
+  lein
+  os-types
+  rstcheck.cfg
+  sbt
+  scalding
+  scalding_repl
+  screenrc
+  source-highlight
+  vimrc
+)
+
+# Files always expected to be linked; print info if missing from dot/
+DOT_DEFAULT=(
+  ackrc
+  tmux
+  zshenv
+  zshrc
+  zshrc.after
+)
+
+is_excluded() {
+  local name="$1"
+  for x in "${DOT_EXCLUDE[@]}"; do
+    [ "$x" = "$name" ] && return 0
+  done
+  return 1
+}
+
 # Clone if not present
 if [ ! -d "$DOT_FILES_DIR" ]; then
   GIT_REPO="${DOT_FILES_GIT_REPO:-git://github.com/manboubird/dot-files.git}"
@@ -22,12 +62,18 @@ if [ -d "$DOT_DIR/config" ]; then
   done
 fi
 
-# dot/<other> → ~/.<name>  (dot prefix added at link time)
+# dot/<other> → ~/.<name>  (dot prefix added at link time; excludes listed above)
 for f in "$DOT_DIR"/*; do
   [ -e "$f" ] || continue  # guard against empty dir glob expansion
   name="$(basename "$f")"
   [ "$name" = "config" ] && continue
+  is_excluded "$name" && continue
   ln -vsf "$f" "$HOME/.$name"
+done
+
+# Verify expected defaults are present
+for name in "${DOT_DEFAULT[@]}"; do
+  [ -e "$DOT_DIR/$name" ] || echo "[info] $name not found in dot/, skipping"
 done
 
 # local/bin/* → ~/local/bin/<name>  (no dot prefix)

--- a/setup/clone_and_link.sh
+++ b/setup/clone_and_link.sh
@@ -45,6 +45,14 @@ is_excluded() {
   return 1
 }
 
+link_one() {
+  local src="$1" target="$2"
+  # Remove existing symlink so ln -sf replaces it rather than nesting inside it.
+  # Real directories are intentionally left alone.
+  [ -L "$target" ] && rm "$target"
+  ln -vsf "$src" "$target"
+}
+
 # Clone if not present
 if [ ! -d "$DOT_FILES_DIR" ]; then
   GIT_REPO="${DOT_FILES_GIT_REPO:-git://github.com/manboubird/dot-files.git}"
@@ -58,7 +66,7 @@ mkdir -p "$XDG_CONFIG_HOME"
 if [ -d "$DOT_DIR/config" ]; then
   for f in "$DOT_DIR/config"/*; do
     [ -e "$f" ] || continue  # guard against empty dir glob expansion
-    ln -vsf "$f" "$XDG_CONFIG_HOME/$(basename "$f")"
+    link_one "$f" "$XDG_CONFIG_HOME/$(basename "$f")"
   done
 fi
 
@@ -68,7 +76,7 @@ for f in "$DOT_DIR"/*; do
   name="$(basename "$f")"
   [ "$name" = "config" ] && continue
   is_excluded "$name" && continue
-  ln -vsf "$f" "$HOME/.$name"
+  link_one "$f" "$HOME/.$name"
 done
 
 # Verify expected defaults are present
@@ -81,7 +89,7 @@ mkdir -p "$HOME/local/bin"
 if [ -d "$DOT_FILES_DIR/local/bin" ]; then
   for f in "$DOT_FILES_DIR/local/bin"/*; do
     [ -e "$f" ] || continue  # guard against empty dir glob expansion
-    ln -vsf "$f" "$HOME/local/bin/$(basename "$f")"
+    link_one "$f" "$HOME/local/bin/$(basename "$f")"
   done
 fi
 


### PR DESCRIPTION
## Summary

- Add `DOT_EXCLUDE` list — 18 legacy/unused files skipped during symlinking (`.bashrc`, `.vimrc`, etc.)
- Add `DOT_DEFAULT` list — 5 expected files always linked; prints `[info]` message if missing from `dot/`
- Add `link_one()` helper — removes existing symlinks before re-linking to prevent nested symlinks on repeated runs

## Test Plan

- [ ] Run `bash setup/clone_and_link.sh` twice — confirm output is identical both times (idempotent)
- [ ] Confirm excluded files (e.g. `.bashrc`, `.vimrc`) are not created in `~/`
- [ ] Confirm default files (`.zshrc`, `.zshenv`, `.zshrc.after`, `.ackrc`, `.tmux`) are linked
- [ ] Confirm `~/.config/` entries resolve directly (e.g. `~/.config/cheat → …/dot/config/cheat`, not nested)

🤖 Generated with [Claude Code](https://claude.com/claude-code)