### PR TITLE
refactor: rename link scripts and add header comments

### DIFF
--- a/local/bin/link_dotfiles_local.sh
+++ b/local/bin/link_dotfiles_local.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
+# link_dotfiles_local.sh — Link private local dotfiles onto this machine.
+#
+# Links files from ~/.dot-files.local/ (private local repo) to $HOME.
+# Runs on top of the public dotfiles already set up by link_dotfiles.sh.
+#
+# PREDEFINED_DEFAULTS are linked silently without prompting.
+# All other files are shown in an interactive numbered menu — select which
+# extras to link (space-separated numbers, 'a'=all, 'n'=none).
+#
+# Safe to re-run: existing symlinks are replaced, real directories left alone.
+# Run whenever you update your private ~/.dot-files.local repo.
+#
+# Usage:
+#   link_dotfiles_local.sh
+#   DOT_FILE_LOCAL_DIR=/path/to/local bash link_dotfiles_local.sh
 set -euo pipefail
 
 DOT_FILE_LOCAL_DIR="${DOT_FILE_LOCAL_DIR:-$HOME/.dot-files.local}"

--- a/setup/link_dotfiles.sh
+++ b/setup/link_dotfiles.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+# link_dotfiles.sh — Bootstrap public dotfiles onto this machine.
+#
+# Clones the public dot-files repo if not present, then symlinks:
+#   dot/*         → ~/.<name>         (dot prefix added at link time)
+#   dot/config/*  → ~/.config/<name>  (XDG config, no dot prefix)
+#   local/bin/*   → ~/local/bin/<name>
+#
+# Safe to re-run: existing symlinks are replaced, real directories left alone.
+# Run once on a new machine, and again after pulling repo updates.
+#
+# Usage:
+#   bash setup/link_dotfiles.sh
+#   DOT_FILES_DIR=/path/to/repo bash setup/link_dotfiles.sh
 set -euo pipefail
 
 DOT_FILES_DIR="${DOT_FILES_DIR:-$HOME/.dot-files}"


### PR DESCRIPTION
## Summary

- Rename `setup/clone_and_link.sh` → `setup/link_dotfiles.sh` (public repo bootstrap)
- Rename `local/bin/link_dot_files_local.sh` → `local/bin/link_dotfiles_local.sh` (private local overlay)
- Add header comments to each script explaining purpose, behavior, and usage

## Test Plan

- [ ] `bash -n setup/link_dotfiles.sh` — syntax OK
- [ ] `bash -n local/bin/link_dotfiles_local.sh` — syntax OK
- [ ] Run `bash setup/link_dotfiles.sh` — symlinks created correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)