### PR TITLE
feat: add symlink-audit and recover modes to dotfile-organizer skill

### DIFF
--- a/docs/setup/dotfile-organizer.md
+++ b/docs/setup/dotfile-organizer.md
@@ -1,39 +1,66 @@
 # Dotfile Organizer Skill — Setup
 
-The `dotfile-organizer` skill helps you audit, configure, and port dot-files based on your machine's installed tools.
+The `dotfile-organizer` skill helps you audit, configure, port, and recover dot-files based on your machine's environment. It is bundled in the dot-files repo under `skills/dotfile-organizer/`.
 
 ## Install the skill
 
-The skill is bundled in the dot-files repo as a Claude Code plugin. Install it once via the Claude Code `/plugin` command.
+### Option A: Symlink (recommended for local use)
 
-**If you installed the dot-files repo from GitHub:**
-
-```
-/plugin marketplace add manboubird/dot-files
-/plugin install dotfile-organizer@dot-files
-```
-
-**If you have the repo cloned locally:**
-
-```
-/plugin marketplace add ~/dot-files
-/plugin install dotfile-organizer@dot-files
-```
-
-Run `/reload-plugins` if the skill doesn't appear immediately.
-
-## Install .claude files
-
-Files in `files/.claude/` are git-managed but require a manual one-time copy since `clone_and_link.sh` cannot safely replace your live `~/.claude/` directory.
+Make the skill available to Claude Code by symlinking it from the repo into `~/.claude/skills/`:
 
 ```bash
-cp ~/dot-files/files/.claude/statusline.sh ~/.claude/statusline.sh
+mkdir -p ~/.claude/skills
+ln -sf ~/.dot-files/skills/dotfile-organizer ~/.claude/skills/dotfile-organizer
 ```
+
+Claude Code discovers skills in `~/.claude/skills/` automatically — no restart needed.
+
+### Option B: Claude marketplace config (GitHub-hosted repo)
+
+If your dot-files repo is hosted on GitHub and you want Claude Code to manage the skill as a plugin, add the repo as a marketplace in `~/.claude/settings.json`:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "dot-files": {
+      "source": {
+        "source": "github",
+        "repo": "manboubird/dot-files"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "dotfile-organizer@dot-files": true
+  }
+}
+```
+
+Then install via Claude Code:
+
+```
+/add-plugin-marketplace dot-files manboubird/dot-files
+/install-plugin dotfile-organizer@dot-files
+```
+
+> **Note:** Option B requires the repo to be publicly accessible on GitHub. For a private fork, use Option A.
+
+## Install `.claude` files
+
+`dot/claude/` contains files managed by git that must be individually symlinked into `~/.claude/` (Claude Code's live directory cannot be fully replaced by a symlink):
+
+```bash
+ln -sf ~/.dot-files/dot/claude/statusline.sh ~/.claude/statusline.sh
+```
+
+This is handled automatically by `setup/link_dotfiles.sh` — no manual step needed after the initial setup.
 
 ## What the skill does
 
 | Mode | Example trigger | Output |
 |------|----------------|--------|
-| **organize** | "what should I configure in .zshrc.local?" | Checklist of .zshenv.local and .zshrc.local entries based on installed tools |
+| **organize** | "what should I configure in .zshrc.local?" | Checklist of `.zshenv.local` and `.zshrc.local` entries based on installed tools |
 | **setup** | "generate a setup checklist for this machine" | Numbered guide saved to `docs/setup/setup-<hostname>.md` |
-| **port** | "what configs should I move into the repo?" | Candidate files with exact move + copy commands |
+| **port** | "what configs should I move into the repo?" | Candidate files with exact move + symlink commands |
+| **security-scan** | "scan for secrets before I push" | Report of secrets, hardcoded paths, and dangerous files in tracked files |
+| **symlink-audit** | "audit my current symlinks" | Broken/nested/old-path/excluded symlinks in `~/` and `~/.config/`, with cleanup commands |
+| **recover** | "restore my deleted .local files" | Scans a backup folder (e.g. `~/.Trash`) for private dotfiles, confirms, and copies them back |

--- a/docs/setup/dotfile-organizer.md
+++ b/docs/setup/dotfile-organizer.md
@@ -15,17 +15,17 @@ ln -sf ~/.dot-files/skills/dotfile-organizer ~/.claude/skills/dotfile-organizer
 
 Claude Code discovers skills in `~/.claude/skills/` automatically — no restart needed.
 
-### Option B: Claude marketplace config (GitHub-hosted repo)
+### Option B: Claude marketplace config (locally cloned repo)
 
-If your dot-files repo is hosted on GitHub and you want Claude Code to manage the skill as a plugin, add the repo as a marketplace in `~/.claude/settings.json`:
+If you want Claude Code to manage the skill as a plugin from the local clone, add the repo path as a marketplace in `~/.claude/settings.json`:
 
 ```json
 {
   "extraKnownMarketplaces": {
     "dot-files": {
       "source": {
-        "source": "github",
-        "repo": "manboubird/dot-files"
+        "source": "local",
+        "path": "~/.dot-files"
       }
     }
   },
@@ -38,11 +38,11 @@ If your dot-files repo is hosted on GitHub and you want Claude Code to manage th
 Then install via Claude Code:
 
 ```
-/add-plugin-marketplace dot-files manboubird/dot-files
+/add-plugin-marketplace dot-files ~/.dot-files
 /install-plugin dotfile-organizer@dot-files
 ```
 
-> **Note:** Option B requires the repo to be publicly accessible on GitHub. For a private fork, use Option A.
+> **Note:** Use the local path option if the repo is private or not hosted on GitHub. If you prefer to point at GitHub directly, replace `"source": "local", "path": "~/.dot-files"` with `"source": "github", "repo": "manboubird/dot-files"`.
 
 ## Install `.claude` files
 

--- a/docs/setup/zshrc.md
+++ b/docs/setup/zshrc.md
@@ -20,30 +20,32 @@
    ```
    This links `dot/*` → `~/.*`, `dot/config/*` → `~/.config/*`, and `local/bin/*` → `~/local/bin/*`.
 
-3. **Link your machine env profile** (pass profile name explicitly on first run):
+3. **Audit existing symlinks** (recommended if this machine already had dotfiles configured):
+
+   Install the dotfile-organizer skill first (see step 7), then ask Claude Code:
+   > "audit my current dotfile symlinks"
+
+   The **symlink-audit** mode scans `~/` and `~/.config/` for broken, nested, old-path, and excluded symlinks and emits cleanup commands. Run any suggested cleanup before proceeding — stale or nested symlinks from a previous setup can cause `link_dotfiles.sh` to silently produce incorrect results on re-runs.
+
+   Skip this step on a clean machine with no prior dotfile setup.
+
+4. **Link your machine env profile** (pass profile name explicitly on first run):
    ```bash
    DOTFILE_MACHINE_PROFILE=<profile> bash ~/.dot-files/setup/link_dot_env.sh
    ```
    After this, `~/.zshenv.local` is a symlink to `env/<profile>/.zshenv.local` (which sets `DOTFILE_MACHINE_PROFILE` for future shells).
 
-4. **Create `~/.config/git/config.local`** from the template:
+5. **Create `~/.config/git/config.local`** from the template:
    ```bash
    cp ~/.dot-files/dot.tpl/gitconfig.local.tpl ~/.config/git/config.local
    # Edit and fill in your name, email, and GitHub username
    ```
 
-5. **Link private local dotfiles** (if you have a `.dot-files.local` repo):
+6. **Link private local dotfiles** (if you have a `.dot-files.local` repo):
    ```bash
    link_dotfiles_local.sh
    ```
    (`link_dotfiles_local.sh` is on PATH via step 2 — it lives in `local/bin/`.)
-
-6. **Install required tools:**
-   ```bash
-   brew install zsh-vi-mode zsh-completions
-   brew install pyenv pyenv-virtualenv
-   brew install zoxide
-   ```
 
 7. **Install the dotfile-organizer skill:**
    ```bash
@@ -52,11 +54,20 @@
    ```
    See [`docs/setup/dotfile-organizer.md`](dotfile-organizer.md) for full setup options including the Claude marketplace config method.
 
-8. **Verify shell starts cleanly:**
+8. **Install required tools:**
+   ```bash
+   brew install zsh-vi-mode zsh-completions
+   brew install pyenv pyenv-virtualenv
+   brew install zoxide
+   ```
+
+9. **Verify shell starts cleanly:**
    ```bash
    zsh -i -c exit; echo "Exit: $?"
    ```
    Expected: `Exit: 0`
+
+   If you have the dotfile-organizer skill installed, you can also ask Claude Code to run **symlink-audit** here as a final check to confirm all expected symlinks are in place and none are broken.
 
 ### Pulling upstream public updates
 

--- a/docs/setup/zshrc.md
+++ b/docs/setup/zshrc.md
@@ -16,7 +16,7 @@
 2. **Clone and link dotfiles:**
    ```bash
    git clone git@your-private-server:you/dot-files.git ~/.dot-files
-   bash ~/.dot-files/setup/clone_and_link.sh
+   bash ~/.dot-files/setup/link_dotfiles.sh
    ```
    This links `dot/*` → `~/.*`, `dot/config/*` → `~/.config/*`, and `local/bin/*` → `~/local/bin/*`.
 
@@ -26,20 +26,33 @@
    ```
    After this, `~/.zshenv.local` is a symlink to `env/<profile>/.zshenv.local` (which sets `DOTFILE_MACHINE_PROFILE` for future shells).
 
-4. **Link private local dotfiles** (if you have a `.dot-files.local` repo):
+4. **Create `~/.config/git/config.local`** from the template:
    ```bash
-   link_dot_files_local.sh
+   cp ~/.dot-files/dot.tpl/gitconfig.local.tpl ~/.config/git/config.local
+   # Edit and fill in your name, email, and GitHub username
    ```
-   (`link_dot_files_local.sh` is now on PATH via step 2.)
 
-5. **Install required tools:**
+5. **Link private local dotfiles** (if you have a `.dot-files.local` repo):
+   ```bash
+   link_dotfiles_local.sh
+   ```
+   (`link_dotfiles_local.sh` is on PATH via step 2 — it lives in `local/bin/`.)
+
+6. **Install required tools:**
    ```bash
    brew install zsh-vi-mode zsh-completions
    brew install pyenv pyenv-virtualenv
    brew install zoxide
    ```
 
-6. **Verify shell starts cleanly:**
+7. **Install the dotfile-organizer skill:**
+   ```bash
+   mkdir -p ~/.claude/skills
+   ln -sf ~/.dot-files/skills/dotfile-organizer ~/.claude/skills/dotfile-organizer
+   ```
+   See [`docs/setup/dotfile-organizer.md`](dotfile-organizer.md) for full setup options including the Claude marketplace config method.
+
+8. **Verify shell starts cleanly:**
    ```bash
    zsh -i -c exit; echo "Exit: $?"
    ```
@@ -63,4 +76,14 @@ git fetch upstream && git merge upstream/main
 | `~/.dot-files/dot/zshrc.command/` | Symlinked as `~/.zshrc.command/` | Per-tool aliases and functions |
 | `~/.dot-files/env/<profile>/.zshenv.local` | Symlinked as `~/.zshenv.local` | Machine-specific env vars (set via `link_dot_env.sh`) |
 | `~/.dot-files/env/<profile>/.zshrc.local` | Symlinked as `~/.zshrc.local` | Machine-specific interactive settings |
-| `~/.dot-files/dot.tpl/gitconfig.local.tpl` | Template | Copy to `~/.config/git/config.local`, do not symlink |
+| `~/.dot-files/dot/claude/statusline.sh` | Symlinked as `~/.claude/statusline.sh` | Claude Code status line script |
+| `~/.dot-files/skills/dotfile-organizer/` | Symlinked as `~/.claude/skills/dotfile-organizer/` | Dotfile organizer Claude skill |
+| `~/.config/git/config.local` | Not symlinked — copy from `dot.tpl/gitconfig.local.tpl` | Git user identity (name, email, GitHub username) |
+
+## Setup scripts reference
+
+| Script | Purpose |
+|--------|---------|
+| `setup/link_dotfiles.sh` | Bootstrap: clone repo if absent, symlink all `dot/` files to `~/` and `~/.config/` |
+| `setup/link_dot_env.sh` | Link `env/<profile>/` files to `~/` (`.zshenv.local`, `.zshrc.local`) |
+| `local/bin/link_dotfiles_local.sh` | Link private `~/.dot-files.local/` overlay files to `~/` |

--- a/skills/dotfile-organizer/SKILL.md
+++ b/skills/dotfile-organizer/SKILL.md
@@ -436,6 +436,8 @@ For each candidate found, determine the restore destination:
 
 **If the user mentioned a specific file or set of files, prioritize those.** If multiple timestamped versions of the same file are found, show them all and ask the user which one to use.
 
+**Alternative source — `~/.config/gh/hosts.yml`:** If `~/.config/git/config.local` is missing or has placeholder values but the backup folder has nothing useful, check `~/.config/gh/hosts.yml` (or the repo-tracked copy at `~/.dot-files/dot/config/gh/hosts.yml`) for the GitHub username. Use it to seed the `[user]` block and ask the user to supply `user.name` and `user.email` for the remaining fields.
+
 **Directory note (`.ssh`, `.gnupg`, `.aws`):** Restoring directories is higher-risk than restoring files — existing contents may be overwritten. Flag these and ask explicitly before proceeding: "Restore `.ssh/` from backup? This will overwrite any existing `~/.ssh/` contents."
 
 ### Step 4: Confirm with the user

--- a/skills/dotfile-organizer/SKILL.md
+++ b/skills/dotfile-organizer/SKILL.md
@@ -1,17 +1,18 @@
 ---
 name: dotfile-organizer
-description: Organize, audit, port, security-scan, and symlink-audit dot-files based on the current machine environment. Use this skill when the user wants to: audit which .zshrc.command files should be active for their installed tools, figure out what to put in .zshrc.local or .zshenv.local, generate a customized step-by-step setup checklist for a new machine, identify machine-specific config files that should be moved into the git-managed dot-files repo, scan tracked files for accidentally committed secrets/hardcoded usernames/privacy leaks before pushing, or inspect current symlinks to find stale/broken/nested links and understand what needs cleanup before running link_dotfiles.sh. Trigger whenever the user mentions organizing dot-files, setting up a new machine, porting configs into the repo, auditing their shell configuration, checking dotfiles for security or privacy issues, or analyzing/auditing current symlinks on their machine.
+description: Organize, audit, port, security-scan, symlink-audit, and recover dot-files based on the current machine environment. Use this skill when the user wants to: audit which .zshrc.command files should be active for their installed tools, figure out what to put in .zshrc.local or .zshenv.local, generate a customized step-by-step setup checklist for a new machine, identify machine-specific config files that should be moved into the git-managed dot-files repo, scan tracked files for accidentally committed secrets/hardcoded usernames/privacy leaks before pushing, inspect current symlinks to find stale/broken/nested links before running link_dotfiles.sh, or restore accidentally-deleted .local files and private dotfiles from a backup folder like ~/.Trash. Trigger whenever the user mentions organizing dot-files, setting up a new machine, porting configs, auditing shell configuration, checking for security issues, auditing symlinks, or recovering/restoring deleted local config files.
 ---
 
 # Dotfile Organizer
 
-Five modes — pick based on what the user is asking for:
+Six modes — pick based on what the user is asking for:
 
 - **organize**: Scan the environment, cross-reference with the dot-files repo, propose what to enable or configure
 - **setup**: Generate a step-by-step machine-specific setup checklist
 - **port**: Identify machine-specific config files outside the repo that should be git-managed, and generate the commands to move them in
 - **security-scan**: Scan tracked files for secrets, hardcoded usernames, and privacy leaks before they reach git history
 - **symlink-audit**: Inspect current symlinks in `~/` and `~/.config/` — find broken, stale, nested, and old-path links, then advise what to clean up before running `link_dotfiles.sh` or `link_dotfiles_local.sh`
+- **recover**: Restore accidentally-deleted `.local` files and other private dotfiles from a backup folder (e.g. `~/.Trash`) back to `$HOME`
 
 ---
 
@@ -376,6 +377,130 @@ bash ~/local/bin/link_dotfiles_local.sh
 ### Output format
 
 Lead with a one-line summary (e.g. "3 issues found: 1 broken, 1 nested, 1 old-path"), then show the categorized findings, then the cleanup commands. Use `- [ ]` checkboxes for cleanup actions.
+
+---
+
+## Mode 6: Recover
+
+Restore private `.local` files and machine-specific dotfiles that were accidentally deleted, after the user points you to a backup folder (e.g. `~/.Trash`, a Time Machine snapshot, a zip extract).
+
+These files are never committed to git — so if they're gone, the only copy is in a backup. The goal is to find the right versions, confirm with the user, and copy them back safely.
+
+### Step 1: Get the backup location from the user
+
+Ask: "Where should I look for the backup? (e.g. `~/.Trash`, a folder path, or press Enter for `~/.Trash`)"
+
+If the user provides no path, default to `~/.Trash`.
+
+### Step 2: Scan the backup folder for candidate files
+
+Search the backup folder (recursively) for files matching the known list of private dotfiles. Show each match with its last-modified date so the user can identify the right version if multiple copies exist.
+
+```bash
+BACKUP="${1:-$HOME/.Trash}"
+
+# Known private dotfile names to look for
+TARGETS=(
+  .zshrc.local .zshenv.local
+  .gitconfig .npmrc .netrc .pypirc
+  .ssh .gnupg .aws
+)
+
+echo "Scanning $BACKUP for private dotfiles..."
+for name in "${TARGETS[@]}"; do
+  # Search one level deep (Trash layout) and also recursively
+  while IFS= read -r found; do
+    [ -e "$found" ] || continue
+    modified=$(stat -f "%Sm" -t "%Y-%m-%d %H:%M" "$found" 2>/dev/null || \
+               stat --format="%y" "$found" 2>/dev/null | cut -c1-16)
+    echo "  $modified  $found"
+  done < <(find "$BACKUP" -name "$name" 2>/dev/null | sort)
+done
+```
+
+### Step 3: Build a restore plan
+
+For each candidate found, determine the restore destination:
+
+| Found file | Restore to |
+|---|---|
+| `.zshrc.local` | `$HOME/.zshrc.local` |
+| `.zshenv.local` | `$HOME/.zshenv.local` |
+| `.gitconfig` | `$HOME/.gitconfig` |
+| `.npmrc` | `$HOME/.npmrc` |
+| `.netrc` | `$HOME/.netrc` |
+| `.pypirc` | `$HOME/.pypirc` |
+| `.ssh/` | `$HOME/.ssh/` (directory — see note) |
+| `.gnupg/` | `$HOME/.gnupg/` (directory — see note) |
+| `.aws/` | `$HOME/.aws/` (directory — see note) |
+
+**If the user mentioned a specific file or set of files, prioritize those.** If multiple timestamped versions of the same file are found, show them all and ask the user which one to use.
+
+**Directory note (`.ssh`, `.gnupg`, `.aws`):** Restoring directories is higher-risk than restoring files — existing contents may be overwritten. Flag these and ask explicitly before proceeding: "Restore `.ssh/` from backup? This will overwrite any existing `~/.ssh/` contents."
+
+### Step 4: Confirm with the user
+
+Present the restore plan as a checklist and ask for confirmation before touching anything:
+
+```
+Found the following files to restore:
+
+  - [ ] ~/.zshrc.local   ← ~/.Trash/.zshrc.local  (2026-03-20 14:32)
+  - [ ] ~/.zshenv.local  ← ~/.Trash/.zshenv.local  (2026-03-20 14:32)
+  - [ ] ~/.gitconfig     ← ~/.Trash/.gitconfig      (2026-03-19 09:15)
+
+Should I restore all of these? (yes / no / list numbers to select, e.g. "1 3")
+```
+
+Wait for the user's answer before proceeding.
+
+### Step 5: Restore the confirmed files
+
+For each confirmed file, copy (not move) from the backup to the destination. If the destination already exists, warn and ask before overwriting:
+
+```bash
+# Check before overwriting
+if [ -e "$DEST" ]; then
+  echo "WARNING: $DEST already exists. Overwrite? (y/n)"
+  # wait for user response
+fi
+cp "$SRC" "$DEST"
+echo "Restored: $DEST"
+```
+
+Set correct permissions on sensitive files after copy:
+
+```bash
+chmod 600 ~/.netrc ~/.npmrc ~/.pypirc 2>/dev/null
+chmod 700 ~/.ssh ~/.gnupg 2>/dev/null
+chmod 600 ~/.ssh/* ~/.gnupg/* 2>/dev/null
+```
+
+### Step 6: Post-recovery verification and next steps
+
+After restoring, verify and advise:
+
+```bash
+# Confirm the files are now in place
+for f in ~/.zshrc.local ~/.zshenv.local ~/.gitconfig ~/.npmrc ~/.netrc; do
+  [ -e "$f" ] && echo "✓ $f" || echo "✗ missing: $f"
+done
+```
+
+Then remind the user of any follow-up steps:
+
+- If `.zshenv.local` was restored and contains `DOTFILE_MACHINE_PROFILE`, re-run:
+  ```bash
+  DOTFILE_MACHINE_PROFILE=<profile> bash ~/.dot-files/setup/link_dot_env.sh
+  ```
+- If `link_dotfiles_local.sh` uses these files as `PREDEFINED_DEFAULTS`, re-run:
+  ```bash
+  bash ~/local/bin/link_dotfiles_local.sh
+  ```
+- If `.gitconfig` was restored, verify git identity:
+  ```bash
+  git config --global user.name; git config --global user.email
+  ```
 
 ---
 

--- a/skills/dotfile-organizer/SKILL.md
+++ b/skills/dotfile-organizer/SKILL.md
@@ -1,16 +1,17 @@
 ---
 name: dotfile-organizer
-description: Organize, audit, port, and security-scan dot-files based on the current machine environment. Use this skill when the user wants to: audit which .zshrc.command files should be active for their installed tools, figure out what to put in .zshrc.local or .zshenv.local, generate a customized step-by-step setup checklist for a new machine, identify machine-specific config files that should be moved into the git-managed dot-files repo, or scan tracked files for accidentally committed secrets, hardcoded usernames, or privacy leaks before pushing. Trigger whenever the user mentions organizing dot-files, setting up a new machine, porting configs into the repo, auditing their shell configuration, or checking dotfiles for security or privacy issues.
+description: Organize, audit, port, security-scan, and symlink-audit dot-files based on the current machine environment. Use this skill when the user wants to: audit which .zshrc.command files should be active for their installed tools, figure out what to put in .zshrc.local or .zshenv.local, generate a customized step-by-step setup checklist for a new machine, identify machine-specific config files that should be moved into the git-managed dot-files repo, scan tracked files for accidentally committed secrets/hardcoded usernames/privacy leaks before pushing, or inspect current symlinks to find stale/broken/nested links and understand what needs cleanup before running link_dotfiles.sh. Trigger whenever the user mentions organizing dot-files, setting up a new machine, porting configs into the repo, auditing their shell configuration, checking dotfiles for security or privacy issues, or analyzing/auditing current symlinks on their machine.
 ---
 
 # Dotfile Organizer
 
-Four modes — pick based on what the user is asking for:
+Five modes — pick based on what the user is asking for:
 
 - **organize**: Scan the environment, cross-reference with the dot-files repo, propose what to enable or configure
 - **setup**: Generate a step-by-step machine-specific setup checklist
 - **port**: Identify machine-specific config files outside the repo that should be git-managed, and generate the commands to move them in
 - **security-scan**: Scan tracked files for secrets, hardcoded usernames, and privacy leaks before they reach git history
+- **symlink-audit**: Inspect current symlinks in `~/` and `~/.config/` — find broken, stale, nested, and old-path links, then advise what to clean up before running `link_dotfiles.sh` or `link_dotfiles_local.sh`
 
 ---
 
@@ -242,6 +243,139 @@ Report findings in three categories:
 **✅ Clean** — no issues found in this category
 
 For each finding: show the file, line number, and the matched content. If errors are found, suggest the fix (move the value to a `.local` file, add to `.gitignore`, or replace with a placeholder in `dot.tpl/`).
+
+---
+
+## Mode 5: Symlink Audit
+
+Scan the current machine's symlinks and report what needs attention before running `link_dotfiles.sh` or `link_dotfiles_local.sh`. The goal is to surface anything that would produce unexpected results — or silently succeed while leaving stale state behind.
+
+### Step 1: Scan symlinks in `~/` and `~/.config/`
+
+Run all three scans in parallel:
+
+```bash
+# Symlinks in ~/ pointing to the dotfiles repos
+DOT_FILES="${DOT_FILES:-$HOME/.dot-files}"
+DOT_FILES_LOCAL="${DOT_FILE_LOCAL_DIR:-$HOME/.dot-files.local}"
+
+echo "=== HOME dotfile symlinks ==="
+for f in "$HOME"/.*; do
+  [ -L "$f" ] || continue
+  target=$(readlink "$f")
+  name=$(basename "$f")
+  [[ "$target" == "$DOT_FILES/"* || "$target" == "$DOT_FILES_LOCAL/"* ]] || continue
+  if [ -e "$f" ]; then
+    [ -d "$target" ] && state="dir-target" || state="ok"
+  else
+    state="BROKEN"
+  fi
+  echo "$state | $name | $target"
+done
+```
+
+```bash
+# Symlinks in ~/.config/ pointing to the dotfiles repos
+DOT_FILES="${DOT_FILES:-$HOME/.dot-files}"
+
+echo "=== XDG config symlinks ==="
+for f in "$HOME/.config"/*; do
+  [ -L "$f" ] || continue
+  target=$(readlink "$f")
+  [[ "$target" == "$DOT_FILES/"* ]] || continue
+  name=$(basename "$f")
+  if [ -e "$f" ]; then
+    [ -d "$target" ] && state="dir-target" || state="ok"
+  else
+    state="BROKEN"
+  fi
+  echo "$state | $name | $target"
+done
+```
+
+```bash
+# Find old-path symlinks (pre-refactoring layout: files/common/ or files/<host>/)
+echo "=== Old-path symlinks ==="
+for f in "$HOME"/.* "$HOME/.config"/*; do
+  [ -L "$f" ] || continue
+  target=$(readlink "$f")
+  [[ "$target" == *"/files/"* ]] && echo "OLD_PATH | $(basename "$f") | $target"
+done
+
+# Check for nested symlinks: evidence of ln -sf being called on an existing dir-target symlink
+echo "=== Nested symlinks (dir-inside-dir) ==="
+for f in "$HOME"/.* "$HOME/.config"/*; do
+  [ -L "$f" ] || continue
+  target=$(readlink -f "$f" 2>/dev/null)
+  [ -z "$target" ] && continue
+  name=$(basename "$f")
+  # Nested: target path ends in name/name (dir was already a symlink, got nested)
+  [[ "$target" == *"/$name/$name" ]] && echo "NESTED | $f | $target"
+done
+```
+
+### Step 2: Cross-reference with script configuration
+
+```bash
+# Load DOT_EXCLUDE and DOT_DEFAULT from the script source
+DOT_FILES="${DOT_FILES:-$HOME/.dot-files}"
+SCRIPT="$DOT_FILES/setup/link_dotfiles.sh"
+
+echo "=== DOT_EXCLUDE (never linked) ==="
+grep -A 30 'DOT_EXCLUDE=(' "$SCRIPT" | awk '/^\)/{exit} /^  /{print $1}'
+
+echo "=== DOT_DEFAULT (expected to be linked) ==="
+grep -A 10 'DOT_DEFAULT=(' "$SCRIPT" | awk '/^\)/{exit} /^  /{print $1}'
+```
+
+Then, for each entry in `DOT_EXCLUDE`: check if `~/.<name>` is still symlinked (it shouldn't be — flag as "excluded but still present").
+
+For each entry in `DOT_DEFAULT`: check if `~/.<name>` is symlinked to the repo's `dot/<name>` (it should be — flag as "expected but missing").
+
+### Step 3: Classify findings
+
+Group results into four categories:
+
+**🔴 Must fix before running link scripts**
+- **Broken symlinks** — target path no longer exists; the link script will not recreate these automatically if the file no longer exists in `dot/`
+- **Nested symlinks** — `~/.config/foo/foo` or similar; indicates the old script ran while the target was already a dir-symlink; requires manual cleanup first
+
+**🟡 Review recommended**
+- **Dir-target symlinks** — `link_one()` in the current script handles these correctly (removes before re-linking), but they're worth knowing about
+- **Old-path symlinks** — pointing to `files/common/` or `files/<host>/` from the pre-refactoring layout; the new script won't update these unless the file now lives under `dot/`
+- **Excluded but still present** — a file is in `DOT_EXCLUDE` but still symlinked; the link script won't remove it, so it'll persist indefinitely unless cleaned up manually
+
+**🟢 Expected and correct**
+- All `DOT_DEFAULT` entries present and pointing to the right `dot/<name>` path
+
+**ℹ️ Informational**
+- Symlinks pointing to `~/.dot-files.local/` (private overlay) — these are managed by `link_dotfiles_local.sh`, not `link_dotfiles.sh`
+
+### Step 4: Output cleanup commands
+
+For each finding that requires action, emit the exact command:
+
+```bash
+# Broken symlink — just remove it; re-run link script if you want it back
+rm ~/.zshrc.after    # broken: target /old/path/dot/zshrc.after no longer exists
+
+# Nested symlink — remove the outer dir-symlink, then re-run link script
+rm -rf ~/.config/cheat   # was: ~/.config/cheat -> dir, ln -sf then created ~/.config/cheat/cheat
+
+# Old-path symlink — re-link to new location
+ln -sf ~/.dot-files/dot/zshrc ~/.zshrc   # was: -> old/files/common/.zshrc
+```
+
+After cleanup commands, remind the user to re-run the appropriate script:
+```bash
+bash ~/.dot-files/setup/link_dotfiles.sh
+# and/or
+bash ~/local/bin/link_dotfiles_local.sh
+```
+
+### Output format
+
+Lead with a one-line summary (e.g. "3 issues found: 1 broken, 1 nested, 1 old-path"), then show the categorized findings, then the cleanup commands. Use `- [ ]` checkboxes for cleanup actions.
 
 ---
 


### PR DESCRIPTION
## Summary

- Add **symlink-audit** mode (Mode 5): scans `~/` and `~/.config/` for broken, nested, old-path, and excluded symlinks; emits cleanup commands before running `link_dotfiles.sh`
- Add **recover** mode (Mode 6): restores accidentally-deleted private dotfiles (`.zshrc.local`, `.zshenv.local`, `.gitconfig`, etc.) from a backup folder (e.g. `~/.Trash`); falls back to `~/.config/gh/hosts.yml` to seed git identity when `config.local` is missing
- Update `docs/setup/dotfile-organizer.md`: fix `.claude` file paths, replace outdated `/plugin` commands with symlink (Option A) and local-path marketplace config (Option B), expand modes table to all 6 modes
- Update `docs/setup/zshrc.md`: fix script names, add skill install step, add symlink-audit step at setup time for machines with existing dotfiles

## Test Plan

- [ ] Verify `dotfile-organizer` skill loads and all 6 modes are described correctly
- [ ] Run symlink-audit on a machine after `link_dotfiles.sh` to confirm broken/nested links are reported
- [ ] Run recover mode pointing at `~/.Trash` to confirm candidate files are found and listed before any copy
- [ ] Follow `docs/setup/zshrc.md` on a clean machine and verify all steps are accurate