### PR TITLE
feat: DOT_EXTRA_SYMLINKS, gitignore settings.local.json, tmux bell monitoring

### DIFF
--- a/dot/config/git/ignore
+++ b/dot/config/git/ignore
@@ -1,1 +1,3 @@
 .DS_Store
+
+**/.claude/settings.local.json

--- a/dot/config/tmux/tmux.conf
+++ b/dot/config/tmux/tmux.conf
@@ -23,6 +23,11 @@ set -g status-keys vi
 # 256 color mode
 set -g default-terminal "screen-256color"
 
+# Bell monitoring — highlight window tab when Claude Code (or any pane) rings a bell
+set-option -g monitor-bell on
+set-option -g bell-action any
+set-option -g visual-bell off
+
 #
 # mouse setting
 #

--- a/local/bin/link_dotfiles_local.sh
+++ b/local/bin/link_dotfiles_local.sh
@@ -115,6 +115,22 @@ main() {
     interactive_select "${extras[@]}"
   fi
 
+  # Link extra dot/ entries declared in DOT_EXTRA_SYMLINKS (set in ~/.zshenv.local)
+  # Format: space-separated names without leading dot, e.g. "source-highlight vimrc"
+  if [ -n "${DOT_EXTRA_SYMLINKS:-}" ]; then
+    local dot_files_dir="${DOT_FILES:-$HOME/.dot-files}"
+    log "Linking DOT_EXTRA_SYMLINKS extras"
+    for name in $DOT_EXTRA_SYMLINKS; do
+      local src="$dot_files_dir/dot/$name"
+      if [ -e "$src" ]; then
+        [ -L "$HOME/.$name" ] && rm "$HOME/.$name"
+        ln -vsf "$src" "$HOME/.$name"
+      else
+        echo "  [warn] DOT_EXTRA_SYMLINKS: $src not found, skipping"
+      fi
+    done
+  fi
+
   # Link local binaries
   if [ -d "$LOCAL_BIN_SRC" ]; then
     log "Linking local binaries to $LOCAL_BIN_DEST"


### PR DESCRIPTION
## Summary

- **`link_dotfiles_local.sh`**: add `DOT_EXTRA_SYMLINKS` env var support — machines can declare extra `dot/` entries to keep symlinked by setting `export DOT_EXTRA_SYMLINKS="source-highlight vimrc"` in `env/<profile>/.zshenv.local`; handles existing dir-symlinks cleanly (removes before re-linking)
- **`dot/config/git/ignore`**: ignore `**/.claude/settings.local.json` — machine-specific Claude Code settings should never be committed
- **`dot/config/tmux/tmux.conf`**: enable bell monitoring so tmux highlights the window tab when Claude Code (or any pane) rings a bell
- **`docs/superpowers/`**: add post-PR#8 XDG machine setup verification plan and symlink audit report for tt-mba-13inch-m4-2025

## Test plan

- [ ] Run `bash setup/link_dotfiles.sh` on a clean machine — verify no change in behaviour
- [ ] Set `export DOT_EXTRA_SYMLINKS="source-highlight vimrc"` in `~/.zshenv.local`, run `link_dotfiles_local.sh` — verify `~/.source-highlight` and `~/.vimrc` are symlinked to `dot/`
- [ ] Run `link_dotfiles_local.sh` a second time — verify no nested symlinks created
- [ ] Confirm `**/.claude/settings.local.json` is matched by `git check-ignore`
- [ ] Open a tmux session, trigger a bell — verify window tab highlights

🤖 Generated with [Claude Code](https://claude.com/claude-code)